### PR TITLE
Reduce stack usage

### DIFF
--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -235,16 +235,16 @@ impl<'pipe> ApduDispatch<'pipe> {
     fn check_for_request(&mut self) -> RequestType {
         if !self.busy() {
             // Check to see if we have gotten a message, giving priority to contactless.
-            let (message, interface) = if let Some(message) = self.contactless.take_request() {
+            let (message, interface) = if let Ok(message) = self.contactless.request() {
                 (message, Interface::Contactless)
-            } else if let Some(message) = self.contact.take_request() {
+            } else if let Ok(message) = self.contact.request() {
                 (message, Interface::Contact)
             } else {
                 return RequestType::None;
             };
 
             // Parse the message as an APDU.
-            match Self::parse_apdu::<{ interchanges::SIZE }>(&message) {
+            match Self::parse_apdu::<{ interchanges::SIZE }>(message) {
                 Ok(command) => {
                     self.response_len_expected = command.expected();
                     // The Apdu may be standalone or part of a chain.

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -297,7 +297,8 @@ impl<'pipe> ApduDispatch<'pipe> {
 
                     let to_send = &res[..boundary];
                     let remaining = res.len() - boundary;
-                    let mut message = interchanges::Data::from_slice(to_send).unwrap();
+                    let mut message = interchanges::Data::new();
+                    message.extend_from_slice(to_send).unwrap();
                     let return_code = if remaining > 255 {
                         // XX = 00 indicates more than 255 bytes of data
                         0x6100u16


### PR DESCRIPTION
This PR contains several patches that reduce stack usage on the lpc55:
- from 22 kB to 3 kB for `ApduDispatch::handle_response`
- from 12 kB to 6 kB for `ApduDispatch::check_for_request`
- from 15 kB to 8 kB for `ApduBuffer::request`